### PR TITLE
fix: Remove keybinding on applet instance when removed from the panel

### DIFF
--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -150,6 +150,10 @@ class CassettoneApplet extends Applet.TextIconApplet {
         return true;
     }
 
+    on_applet_removed_from_panel(deleteConfig) {
+        Main.keybindingManager.removeHotKey("show-directory-menu-" + this.instance_id);
+    }
+
     open_cassettone() {
         this._applet_tooltip.hide();
         this._applet_tooltip.preventShow = true;


### PR DESCRIPTION
After setting a keybinding if you reload the applet, the menu opening process becomes inconsistent. The reason for this is that what happens during the reload is that the current applet instance is removed from the panel, and then another new instance is added in place, but it seems that the applet is not completely removed after the reload so using the keybinding would open a menu for the removed applet first, which is not on the panel, therefore the menu won't appear in its correct location.

### Example of the issue

https://github.com/rcalixte/cinnamon-spices-applets/assets/63073056/eec97d15-0f59-40ca-96ed-625174303a71

If you noticed in some parts of the video where the mouse cursor was stopped on the screen I was constantly clicking the keys to try to open the menu, and only after some time, it opens (which is also a consequence of the same issue).